### PR TITLE
Fix incorrect variable name

### DIFF
--- a/netatmo.10m.php
+++ b/netatmo.10m.php
@@ -79,7 +79,7 @@ if(is_array($json)) {
 		case ($battery_percent >= 50):
 			$battery_status_icon = "\u{1F7E2}";
 			break;
-		case ($battery_percent < 50 && $battery > 10):
+		case ($battery_percent < 50 && $battery_percent > 10):
 			$battery_status_icon = "\u{1F7E0}";
 			break;
 		case ($battery_percent <= 10):


### PR DESCRIPTION
Just a simple change from `$battery` to `$battery_percent` to prevent a syntax error. Thanks for sharing this script!